### PR TITLE
Update class-vc-mapper.php

### DIFF
--- a/include/classes/core/class-vc-mapper.php
+++ b/include/classes/core/class-vc-mapper.php
@@ -183,8 +183,10 @@ class Vc_Mapper {
 	public function callElementActivities( $tag ) {
 		do_action( 'vc_mapper_call_activities_before' );
 		if ( isset( $this->element_activities[ $tag ] ) ) {
-			while ( $activity = each( $this->element_activities[ $tag ] ) ) {
-				list( $method, $params ) = $activity[1];
+				//AK - fixed each Bug @14-5-2020
+			foreach ( $this->element_activities as $activity ) {
+            			list( $method, $params ) = $activity;
+           			 //AK- Fixed- Bug \\	
 				switch ( $method ) {
 					case 'drop_param':
 						WPBMap::dropParam( $params['name'], $params['attribute_name'] );


### PR DESCRIPTION
Fixed  following PHP each bug  Tested on WP- 5.4.1 & PHP 7.2.1 

`PHP Deprecated:  The each() function is deprecated. This message will be suppressed on further calls in /work/mine/www/trantor/wp-content/plugins/js_composer/include/classes/core/class-vc-mapper.php on line 186`